### PR TITLE
Correct segment index.

### DIFF
--- a/src/SFNT/tables/cmaps/format4/Segments.js
+++ b/src/SFNT/tables/cmaps/format4/Segments.js
@@ -9,7 +9,7 @@ define(["Segment", "dataBuilding"], function(Segment, dataBuilder) {
 
   Segments.prototype = {
     addSegment: function(code) {
-      var idx = this.data.length + 1;
+      var idx = this.data.length;
       this.data.push(new Segment({
         end: code,
         start: code,


### PR DESCRIPTION
When encoding multiple letters, the segments seem to shift, which I think is caused by an off-by-one error in addSegment. I've applied the fix in my code and it seems to work -- code segments align correctly with the glyphs.

Since you're only encoding one glyph it might be that you've never encountered the issue. Or I might be completely wrong :-)

Note that I've only tested this with cmap format 4 -- other formats might cause different issues.
