### PR TITLE
Make build step more explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _res
 .DS_Store
+node_modules
 test

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ to an SVG (compound) path, and get a BASE64-encoded OTF back for
 use in an @font-face src property. Define outline, load in, apply
 to single letter.
 
-The code can be built with `node r.js -o build` (windows users will
-probably need to do something stupid like `node c:\Users\YourNameHere\AppData\Roaming\npm\node_modules\requirejs\bin\r.js -o build.js`
+The code can be built with:
+
+```sh
+npm install requirejs
+export PATH="$(npm bin):$PATH"
+r.js -o build.js
+```
+
+(Windows users will probably need to do something stupid like
+`node node_modules\requirejs\bin\r.js -o build.js`
 because r.js was not packaged as nicely as npm or browserify)
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ r.js -o build.js
 ```
 
 (Windows users will probably need to do something stupid like
-`node node_modules\requirejs\bin\r.js -o build.js`
+`node node\_modules\requirejs\bin\r.js -o build.js`
 because r.js was not packaged as nicely as npm or browserify)
 
 


### PR DESCRIPTION
I had trouble running the build by following instructions in the README.

I simplified the build by installing requirejs locally and updated the instructions to run the build successfully.

Kudos to http://stackoverflow.com/a/24417867 for the `npm bin` trick.
